### PR TITLE
Fix hostname value typo

### DIFF
--- a/databases/postgre.toml
+++ b/databases/postgre.toml
@@ -3,7 +3,7 @@ pattern = "DEV"
 
 [database.shared_db]
 type = "postgresql"
-hostname = "mysql.example.com"
+hostname = "postgre.example.com"
 database = "wso2isdb"
 password = "$secret{db_password}"
 


### PR DESCRIPTION
Fix typo that gives the hostname value as "mysql.example.com" to "postgre.example.com"